### PR TITLE
docs: add Obsidian notes for services

### DIFF
--- a/api-gateway/docs/api-gateway.md
+++ b/api-gateway/docs/api-gateway.md
@@ -1,0 +1,4 @@
+# api-gateway
+
+FastAPI entry point for video generation jobs.
+Receives client requests, performs basic validation and enqueues tasks for the orchestrator.

--- a/assets/docs/assets.md
+++ b/assets/docs/assets.md
@@ -1,0 +1,4 @@
+# assets
+
+MinIO-compatible S3 storage for images, audio and videos.
+Acts as central repository for intermediate and final artifacts.

--- a/broker/docs/broker.md
+++ b/broker/docs/broker.md
@@ -1,0 +1,4 @@
+# broker
+
+RabbitMQ message broker handling task and event queues.
+Facilitates communication between microservices.

--- a/cache/docs/cache.md
+++ b/cache/docs/cache.md
@@ -1,0 +1,4 @@
+# cache
+
+Redis cache used for JWTs, rate limiting and idempotency keys.
+Provides fast key-value storage for transient data.

--- a/db/docs/db.md
+++ b/db/docs/db.md
@@ -1,0 +1,4 @@
+# db
+
+PostgreSQL database storing job status, metadata and outbox events.
+Used by services to persist workflow progress.

--- a/image-service/docs/image-service.md
+++ b/image-service/docs/image-service.md
@@ -1,0 +1,4 @@
+# image-service
+
+Generates images for each scenario chapter using Stable Diffusion.
+Uploads resulting frames to the asset store.

--- a/observability/docs/observability.md
+++ b/observability/docs/observability.md
@@ -1,0 +1,4 @@
+# observability
+
+ElasticSearch, Logstash and Kibana stack for collecting metrics and logs.
+Helps monitor service health and debug issues.

--- a/orchestrator/docs/orchestrator.md
+++ b/orchestrator/docs/orchestrator.md
@@ -1,0 +1,4 @@
+# orchestrator
+
+Celery worker coordinating the entire generation pipeline.
+It decomposes jobs into scenario, image, TTS and composition tasks and tracks their completion.

--- a/scenario-service/docs/scenario-service.md
+++ b/scenario-service/docs/scenario-service.md
@@ -1,0 +1,4 @@
+# scenario-service
+
+Service that uses language models to create video scenarios.
+Provides scripts and chapter breakdown for subsequent stages.

--- a/tts-service/docs/tts-service.md
+++ b/tts-service/docs/tts-service.md
@@ -1,0 +1,4 @@
+# tts-service
+
+Text-to-speech generator producing narration audio from scenario text.
+Resulting audio files are stored for later video composition.

--- a/video-composer/docs/video-composer.md
+++ b/video-composer/docs/video-composer.md
@@ -1,0 +1,4 @@
+# video-composer
+
+Assembles final video from frames, narration and optional music with FFmpeg.
+Outputs a ready-to-share video file in the asset store.


### PR DESCRIPTION
## Summary
- add `docs` folders and Obsidian notes for all microservices and infrastructure services

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b71d58ec7483209c5c7efa29e28796