### PR TITLE
Add YAML content type and download support to S3AsyncSaver

### DIFF
--- a/assets_service/src/saver/s3_saver.py
+++ b/assets_service/src/saver/s3_saver.py
@@ -50,5 +50,12 @@ class S3AsyncSaver:
                 ".jpeg": "image/jpeg",
                 ".webp": "image/webp",
                 ".wav": "audio/wav",
+                ".yaml": "application/x-yaml",
+                ".yml": "application/x-yaml",
             }.get(ext, "application/octet-stream")
         await self._s3.put_object(Bucket=self.bucket, Key=key, Body=data, ContentType=content_type)
+
+    async def download(self, key: str) -> bytes:
+        response = await self._s3.get_object(Bucket=self.bucket, Key=key)
+        async with response["Body"] as stream:
+            return await stream.read()


### PR DESCRIPTION
## Summary
- add YAML content type detection for uploads when saving objects to S3
- implement a download method for retrieving objects from S3 asynchronously

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c87ed7ab68832097157011ae0d3605